### PR TITLE
:bug: Fix client endpoint option bug

### DIFF
--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -4,7 +4,7 @@ module GarageClient
 
     def self.property(key)
       define_method(key) do
-        options.fetch(key, GarageClient.configuration.send(key))
+        options.fetch(key) { GarageClient.configuration.send(key) }
       end
 
       define_method("#{key}=") do |value|

--- a/spec/garage_client/client_spec.rb
+++ b/spec/garage_client/client_spec.rb
@@ -135,8 +135,8 @@ describe GarageClient::Client do
 
   describe "#endpoint=" do
     it "overwrites it" do
-      client.adapter = "http://example.com"
-      client.adapter.should == "http://example.com"
+      client.endpoint = "http://example.com"
+      client.endpoint.should == "http://example.com"
     end
   end
 

--- a/spec/garage_client/client_spec.rb
+++ b/spec/garage_client/client_spec.rb
@@ -4,6 +4,24 @@ describe GarageClient::Client do
   let(:client) { GarageClient::Client.new(options) }
   let(:options) { {} }
 
+  describe 'laziness of properties' do
+    before { allow(GarageClient.configuration).to receive(:endpoint).and_raise('error') }
+
+    context 'when is specified options' do
+      let(:options) { { endpoint: 'http://example.com' } }
+
+      it 'does not evaluate global configuration' do
+        expect { client.endpoint }.not_to raise_error
+      end
+    end
+
+    context 'when is not specified options' do
+      it 'evaluates global configuration' do
+        expect { client.endpoint }.to raise_error('error')
+      end
+    end
+  end
+
   describe "#adapter" do
     context "without :adapter option value" do
       it "returns default value" do


### PR DESCRIPTION
Client endpoint option check -> [here](https://github.com/cookpad/garage_client/blob/master/lib/garage_client/client.rb#L84)

but `default_options#endpoint` rise error when not set default endpoint. -> [here](https://github.com/cookpad/garage_client/blob/master/lib/garage_client/configuration.rb#L41)