### PR TITLE
Add request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ There are the following options:
 - `endpoint` - Garage application API endpoint (default: nil)
 - `path_prefix` - API path prefix (default: `'/v1'`)
 - `verbose` - Enable verbose http log (default: `false`)
+- `request` - default http request options (Faraday::RequestOptions ```:params_encoder, :proxy, :bind, :timeout, :open_timeout, :boundary```)
 
 You can configure the global settings:
 
@@ -103,6 +104,7 @@ You can configure the global settings:
 GarageClient.configure do |c|
   c.endpoint = "http://localhost:3000"
   c.verbose = true
+  c.request = { timeout: 5 }
 end
 ```
 
@@ -115,8 +117,16 @@ client = GarageClient::Client.new(
   endpoint: "http://localhost:3000",
   path_prefix: "/v2",
   verbose: true,
+  request: { timeout: 3 },
 )
 ```
+
+or each request settings:
+
+```ruby
+client.post("/touch", "touch message", headers: { 'User-Agent' => 'garage_client_ext' }, request: { timeout: 1 })
+```
+
 
 ## Exceptions
 GarageClient raises one of the following exceptions upon an error.

--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -56,7 +56,7 @@ module GarageClient
     end
 
     def connection
-      Faraday.new(headers: headers, url: endpoint) do |builder|
+      Faraday.new(headers: headers, url: endpoint, request: request_options) do |builder|
         # Response Middlewares
         builder.use Faraday::Response::Logger if verbose
         builder.use FaradayMiddleware::Mashify
@@ -72,6 +72,14 @@ module GarageClient
         apply_auth_middleware builder
         builder.adapter(*adapter)
       end
+    end
+
+    def request_options
+      options[:request] || default_options.options[:request]
+    end
+
+    def request_options=(value)
+      options[:request] = value
     end
 
     private

--- a/lib/garage_client/configuration.rb
+++ b/lib/garage_client/configuration.rb
@@ -9,6 +9,7 @@ module GarageClient
       },
       path_prefix: '/v1',
       verbose: false,
+      request: nil,
     }
 
     def self.keys

--- a/lib/garage_client/request.rb
+++ b/lib/garage_client/request.rb
@@ -24,6 +24,7 @@ module GarageClient
         request.url(path, params)
         request.body = body if body
         request.headers.update(options[:headers]) if options[:headers]
+        request.options.update(options[:request]) if options[:request]
       end
       options[:raw] ? response : GarageClient::Response.new(self, response)
     end

--- a/spec/garage_client/client_spec.rb
+++ b/spec/garage_client/client_spec.rb
@@ -243,4 +243,48 @@ describe GarageClient::Client do
       end
     end
   end
+
+  describe '#request_options' do
+    around do |example|
+      begin
+        old, GarageClient.request = GarageClient.request, nil
+        example.run
+      ensure
+        GarageClient.request = old
+      end
+    end
+
+    context 'in default' do
+      it 'returns nil' do
+        expect(client.request_options).to be_nil
+      end
+    end
+
+    context 'when request options configured' do
+      before do
+        GarageClient.request = { timeout: 5 }
+      end
+      it 'returns configured value' do
+        expect(client.request_options).to eq(timeout: 5)
+      end
+    end
+
+    context 'when is specified options' do
+      let(:options) { { request: { timeout: 10 } } }
+
+      it 'returns specified value' do
+        expect(client.request_options).to eq(timeout: 10)
+      end
+    end
+  end
+
+  describe '#request_options=' do
+    let(:request_options) { { request: { timeout: 10 } } }
+
+    it 'overwrites it' do
+      expect {
+        client.request_options = request_options
+      }.to change { client.request_options }.from(nil).to(request_options)
+    end
+  end
 end

--- a/spec/garage_client/configuration_spec.rb
+++ b/spec/garage_client/configuration_spec.rb
@@ -103,4 +103,22 @@ describe GarageClient::Configuration do
       end
     end
   end
+
+  describe '#request' do
+    context 'in default configuration' do
+      it 'returns nil' do
+        expect(configuration.request).to be_nil
+      end
+    end
+
+    context 'after configured' do
+      before do
+        configuration.request = { timeout: 3 }
+      end
+
+      it 'returns configured value' do
+        expect(configuration.request).to eq(timeout: 3)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Set request options each client or request

``` ruby
GarageClient.configure do |c|
  c.request = { timeout: 5 }
end
```

``` ruby
client = GarageClient::Client.new(request: { timeout: 3 })
```

``` ruby
client.get('/touch', nil, request: { timeout: 1 })
```
