### PR TITLE
Override respond_to_missing? when method_missing is overridden

### DIFF
--- a/lib/garage_client/resource.rb
+++ b/lib/garage_client/resource.rb
@@ -52,8 +52,8 @@ module GarageClient
       end
     end
 
-    def respond_to?(name)
-      super || !!(properties.include?(name) || links.include?(name) || nested_resource_creation_method?(name))
+    def respond_to_missing?(name, include_private)
+      !!(properties.include?(name) || links.include?(name) || nested_resource_creation_method?(name))
     end
 
     def nested_resource_creation_method?(name)

--- a/lib/garage_client/response.rb
+++ b/lib/garage_client/response.rb
@@ -98,8 +98,8 @@ module GarageClient
       parsed_link_header.try(:find_link, %w[rel last])
     end
 
-    def respond_to?(name, *args)
-      super || body.respond_to?(name, *args)
+    def respond_to_missing?(name, include_private)
+      body.respond_to?(name, include_private)
     end
 
     private

--- a/spec/garage_client/response_spec.rb
+++ b/spec/garage_client/response_spec.rb
@@ -72,6 +72,24 @@ describe GarageClient::Response do
     end
   end
 
+  describe "#method" do
+    context "with same property" do
+      before do
+        body["name"] = "example"
+      end
+
+      it "returns method object" do
+        response.method(:name).should be_kind_of(Method)
+      end
+    end
+
+    context "with neithor same property nor same method" do
+      it "raises an error" do
+        expect { response.method(:name) }.to raise_error(NameError)
+      end
+    end
+  end
+
   describe "#has_next_page?" do
     context "without Link header" do
       before do


### PR DESCRIPTION
Without respond_to_missing? overridden, `method` method would fail with
NameError.

@cookpad/garage please review