### PR TITLE
Better error message for unexpected property access

### DIFF
--- a/lib/garage_client/resource.rb
+++ b/lib/garage_client/resource.rb
@@ -48,7 +48,7 @@ module GarageClient
         path = data._links[name.to_s.sub(/create_/, '')].href
         client.post(path, *args)
       else
-        super
+        raise NoMethodError.new("undefined method `#{name}' for #{data}")
       end
     end
 

--- a/lib/garage_client/response.rb
+++ b/lib/garage_client/response.rb
@@ -105,11 +105,7 @@ module GarageClient
     private
 
     def method_missing(name, *args, &block)
-      if body.respond_to?(name)
-        body.send(name, *args, &block)
-      else
-        super
-      end
+      body.send(name, *args, &block)
     end
 
     def dictionary_response?


### PR DESCRIPTION
Before:

```
lib/garage_client/response.rb:111:in `method_missing': undefined method `name' for #<GarageClient::Response:0x00000002fdebf0> (NoMethodError)
```

After:

```
lib/garage_client/resource.rb:51:in `method_missing': undefined method `name' for #<Hashie::Mash error="Sorry, something went wrong"> (NoMethodError)
```

@cookpad/garage What do you think?