### PR TITLE
Add 4xx client errors and 5xx server errors handling

### DIFF
--- a/lib/garage_client/error.rb
+++ b/lib/garage_client/error.rb
@@ -27,6 +27,8 @@ module GarageClient
   class Conflict < Error; end
   class UnsupportedMediaType < Error; end
   class UnprocessableEntity < Error; end
+  class ClientError < Error; end
+  class ServerError < Error; end
 
   # Remote Server
   class InternalServerError < Error; end

--- a/lib/garage_client/response/raise_http_exception.rb
+++ b/lib/garage_client/response/raise_http_exception.rb
@@ -4,6 +4,9 @@ require 'faraday_middleware'
 module GarageClient
   class Response
     class RaiseHttpException < Faraday::Response::Middleware
+      ClientErrorStatuses = 400...500
+      ServerErrorStatuses = 500...600
+
       def call(env)
         @app.call(env).on_complete do |response|
           resp = response
@@ -28,6 +31,10 @@ module GarageClient
             raise GarageClient::InternalServerError.new(resp)
           when 503
             raise GarageClient::ServiceUnavailable.new(resp)
+          when ClientErrorStatuses
+            raise GarageClient::ClientError.new(resp)
+          when ServerErrorStatuses
+            raise GarageClient::ServerError.new(resp)
           end
         end
       end

--- a/spec/garage_client/response_spec.rb
+++ b/spec/garage_client/response_spec.rb
@@ -437,6 +437,13 @@ describe Faraday::Response do
       422 => GarageClient::UnprocessableEntity,
       500 => GarageClient::InternalServerError,
       503 => GarageClient::ServiceUnavailable,
+
+      402 => GarageClient::ClientError,
+      405 => GarageClient::ClientError,
+      407 => GarageClient::ClientError,
+      408 => GarageClient::ClientError,
+      502 => GarageClient::ServerError,
+      504 => GarageClient::ServerError,
     }.each do |status, exception|
       context "when HTTP status is #{status}" do
         before do


### PR DESCRIPTION
Error raised, when a API returns 4xx client errors or 5xx server errors.

@cookpad/dev-infra :eyeglasses: 