### PR TITLE
Allow rescuing 4xx or 5xx errors

### DIFF
--- a/lib/garage_client/error.rb
+++ b/lib/garage_client/error.rb
@@ -28,11 +28,11 @@ module GarageClient
   class UnsupportedMediaType < Error; end
   class UnprocessableEntity < Error; end
   class ClientError < Error; end
-  class ServerError < Error; end
 
   # Remote Server
-  class InternalServerError < Error; end
-  class ServiceUnavailable < Error; end
+  class ServerError < Error; end
+  class InternalServerError < ServerError; end
+  class ServiceUnavailable < ServerError; end
 
   # GarageClient Client
   class UnsupportedResource < Error; end

--- a/lib/garage_client/error.rb
+++ b/lib/garage_client/error.rb
@@ -19,15 +19,15 @@ module GarageClient
   end
 
   # HTTP level
-  class BadRequest < Error; end
-  class Unauthorized < Error; end
-  class Forbidden < Error; end
-  class NotFound < Error; end
-  class NotAcceptable < Error; end
-  class Conflict < Error; end
-  class UnsupportedMediaType < Error; end
-  class UnprocessableEntity < Error; end
   class ClientError < Error; end
+  class BadRequest < ClientError; end
+  class Unauthorized < ClientError; end
+  class Forbidden < ClientError; end
+  class NotFound < ClientError; end
+  class NotAcceptable < ClientError; end
+  class Conflict < ClientError; end
+  class UnsupportedMediaType < ClientError; end
+  class UnprocessableEntity < ClientError; end
 
   # Remote Server
   class ServerError < Error; end


### PR DESCRIPTION
Since all exception's base class is GarageClient::Error, we can't rescue all 4xx errors or 5xx errors.
I changed 4xx erros to be a subclass of `ClientError` and 5xx errors to be a subclass of `ServerError`.