### PR TITLE
Require application name for embedding as User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ There are the following options:
 
 - `adapter` - faraday adapter for http client (default: `:net_http`)
 - `cacher` - take a cacher class in which caching logic is defined (default: nil)
-- `headers` - default http headers (default: `{ "Accept" => "application/json", "User-Agent" => "garage_client #{VERSION}" }`)
+- `name` - Client's application name, which is embedded in User-Agent by default (default: nil)
+- `headers` - default http headers (default: `{ "Accept" => "application/json", "User-Agent" => "garage_client #{VERSION} #{name}" }`)
 - `endpoint` - Garage application API endpoint (default: nil)
 - `path_prefix` - API path prefix (default: `'/v1'`)
 - `verbose` - Enable verbose http log (default: `false`)
@@ -102,6 +103,7 @@ You can configure the global settings:
 ```ruby
 GarageClient.configure do |c|
   c.endpoint = "http://localhost:3000"
+  c.name = 'my-awesome-client'
   c.verbose = true
 end
 ```
@@ -113,6 +115,7 @@ client = GarageClient::Client.new(
   adapter: :test,
   headers: { "Host" => "garage.example.com" },
   endpoint: "http://localhost:3000",
+  name: 'my-awesome-client',
   path_prefix: "/v2",
   verbose: true,
 )

--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -85,6 +85,9 @@ module GarageClient
       if !options[:endpoint] && !default_options.endpoint
         raise "Missing endpoint configuration"
       end
+      if !options[:name] && !default_options.name
+        raise "Missing name configuration"
+      end
     end
 
     def default_options

--- a/lib/garage_client/configuration.rb
+++ b/lib/garage_client/configuration.rb
@@ -3,16 +3,12 @@ module GarageClient
     DEFAULTS = {
       adapter: :net_http,
       cacher: nil,
-      headers: {
-        'Accept' => 'application/json',
-        'User-Agent' => "garage_client #{GarageClient::VERSION}",
-      },
       path_prefix: '/v1',
       verbose: false,
     }
 
     def self.keys
-      DEFAULTS.keys + [:endpoint]
+      DEFAULTS.keys + [:endpoint, :headers]
     end
 
     def initialize(options = {})
@@ -43,6 +39,31 @@ module GarageClient
 
     def endpoint=(value)
       options[:endpoint] = value
+    end
+
+    def name
+      options[:name] or raise 'Configuration error: missing name'
+    end
+
+    def name=(value)
+      options[:name] = value
+    end
+
+    def default_user_agent
+      "garage_client #{GarageClient::VERSION} #{name}"
+    end
+
+    def headers
+      options.fetch(:headers) do
+        {
+          'Accept' => 'application/json',
+          'User-Agent' => default_user_agent,
+        }
+      end
+    end
+
+    def headers=(value)
+      options[:headers] = value
     end
 
     alias :default_headers :headers

--- a/spec/features/configuration_spec.rb
+++ b/spec/features/configuration_spec.rb
@@ -23,7 +23,7 @@ describe "Configuration of GarageClient" do
       prev = GarageClient.configuration
       GarageClient.instance_variable_set(
         :@configuration,
-        GarageClient::Configuration.new(endpoint: "https://garage.example.com")
+        GarageClient::Configuration.new(endpoint: "https://garage.example.com", name: "configuration_spec")
       )
 
       example.run

--- a/spec/garage_client/client_spec.rb
+++ b/spec/garage_client/client_spec.rb
@@ -110,7 +110,7 @@ describe GarageClient::Client do
         client.headers.should == {
           "Accept" => "application/json",
           "Content-Type" => "text/plain",
-          "User-Agent" => "garage_client #{GarageClient::VERSION}"
+          "User-Agent" => "garage_client #{GarageClient::VERSION} garage_client_spec"
         }
       end
     end

--- a/spec/garage_client/configuration_spec.rb
+++ b/spec/garage_client/configuration_spec.rb
@@ -42,11 +42,23 @@ describe GarageClient::Configuration do
   end
 
   describe "#headers" do
+    context "name isn't configured" do
+      it "raises RuntimeError" do
+        expect { configuration.headers }.to raise_error(RuntimeError, /missing name/)
+      end
+    end
+
     context "in default configuration" do
+      let(:name) { 'configuration_spec' }
+
+      before do
+        configuration.name = name
+      end
+
       it "returns default headers as Hash" do
         configuration.headers.should == {
           "Accept" => "application/json",
-          "User-Agent" => "garage_client #{GarageClient::VERSION}",
+          "User-Agent" => "garage_client #{GarageClient::VERSION} #{name}",
         }
       end
     end
@@ -63,6 +75,10 @@ describe GarageClient::Configuration do
   end
 
   describe "#default_headers" do
+    before do
+      configuration.name = 'configuration_spec'
+    end
+
     it "returns configuration.headers" do
       configuration.default_headers.should == configuration.headers
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'garage_client'
 GarageClient.configure do |c|
   c.path_prefix = ''
   c.endpoint = "https://garage.example.com"
+  c.name = 'garage_client_spec'
 end
 
 # This workaround is strictly for stubbing purpose.


### PR DESCRIPTION
For easy understanding from access logs what application is accessing.

@cookpad/garage @cookpad/dev-infra What do you think?