### PR TITLE
Set rails application name by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ There are the following options:
 
 - `adapter` - faraday adapter for http client (default: `:net_http`)
 - `cacher` - take a cacher class in which caching logic is defined (default: nil)
-- `name` - Client's application name, which is embedded in User-Agent by default (default: nil)
+- `name` - Client's application name, which is embedded in User-Agent by default (default: nil. For Rails, `Rails.application.class.parent_name.underscore` is set by default.)
 - `headers` - default http headers (default: `{ "Accept" => "application/json", "User-Agent" => "garage_client #{VERSION} #{name}" }`)
 - `endpoint` - Garage application API endpoint (default: nil)
 - `path_prefix` - API path prefix (default: `'/v1'`)

--- a/garage_client.gemspec
+++ b/garage_client.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'system_timer' if RUBY_VERSION < '1.9'
 
+  s.add_development_dependency "rails"
   s.add_development_dependency "rake", ">= 0.9.2"
   s.add_development_dependency "rspec"
   s.add_development_dependency "json"

--- a/lib/garage_client.rb
+++ b/lib/garage_client.rb
@@ -15,6 +15,13 @@ require 'garage_client/response/raise_http_exception'
 require 'garage_client/resource'
 require 'garage_client/client'
 
+begin
+  require 'rails'
+rescue LoadError
+else
+  require 'garage_client/railtie'
+end
+
 module GarageClient
   class << self
     GarageClient::Configuration.keys.each do |key|

--- a/lib/garage_client/railtie.rb
+++ b/lib/garage_client/railtie.rb
@@ -1,0 +1,17 @@
+module GarageClient
+  class Railtie < ::Rails::Railtie
+    initializer :garage_client do |app|
+      RailsInitializer.set_default_name
+    end
+  end
+
+  module RailsInitializer
+    def self.set_default_name
+      unless GarageClient.configuration.options[:name]
+        GarageClient.configure do |c|
+          c.name = Rails.application.class.parent_name.underscore
+        end
+      end
+    end
+  end
+end

--- a/spec/garage_client/railtie_spec.rb
+++ b/spec/garage_client/railtie_spec.rb
@@ -1,0 +1,40 @@
+describe GarageClient::Railtie do
+  describe 'initializer' do
+    let(:parent_name) { 'Cookpad' }
+
+    before do
+      allow(Rails).to receive_message_chain(:application, :class, :parent_name).
+        and_return(parent_name)
+    end
+
+    context 'when GarageClient.configuration.name is absent' do
+      before do
+        GarageClient.configuration.name = nil
+      end
+
+      it 'sets name by Rails.application.class.parent_name' do
+        expect {
+          GarageClient::RailsInitializer.set_default_name
+        }.to change {
+          GarageClient.configuration.options[:name]
+        }.from(nil).to(parent_name.underscore)
+      end
+    end
+
+    context 'when GarageClient.configuration.name is present' do
+      let(:name) { 'cookpad2' }
+
+      before do
+        GarageClient.configuration.name = name
+      end
+
+      it 'does not override name' do
+        expect {
+          GarageClient::RailsInitializer.set_default_name
+        }.to_not change {
+          GarageClient.configuration.options[:name]
+        }.from(name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related to: https://github.com/cookpad/garage_client/pull/14

This patch introduces a railtie which sets Rails application name to `GarageClient.configuration.name` if it's not specified. When `Rails.application.class` is `Cookpad::Application`, `GarageClient.configuration.name` will be `"cookpad"`.

@cookpad/dev-infra How do you think about this?