### PR TITLE
See top level Rails

### DIFF
--- a/lib/garage_client/railtie.rb
+++ b/lib/garage_client/railtie.rb
@@ -9,7 +9,7 @@ module GarageClient
     def self.set_default_name
       unless GarageClient.configuration.options[:name]
         GarageClient.configure do |c|
-          c.name = Rails.application.class.parent_name.underscore
+          c.name = ::Rails.application.class.parent_name.underscore
         end
       end
     end


### PR DESCRIPTION
[garage_client-rails](https://github.com/tokubai/garage_client-rails)
has `GarageClient::Rails` module, so this initializer method misses
`Rails.application` method.