### PR TITLE
Do not support under 2.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rvm:
   - ruby-head
   - 2.3.1
   - 2.2.5
-  - 2.1.10
 matrix:
   allow_failures:
     - rvm: "ruby-head"


### PR DESCRIPTION
rack 2 requires ruby version >= 2.2.2
garage_client depends on rack through rails only in development dependencies,
so there is no necessity to set gem.required_ruby_version.

WDYT?