### PR TITLE
Support latest faraday

### DIFF
--- a/lib/garage_client/cachers/base.rb
+++ b/lib/garage_client/cachers/base.rb
@@ -11,7 +11,13 @@ module GarageClient
         if response
           # Faraday::Response#marshal_dump is drop request object and url
           # https://github.com/lostisland/faraday/blob/edacd5eb57ea13accab3097649690ae5f48f421a/lib/faraday/response.rb#L74
-          response.env.merge!(@env) {|_, self_val, other_val| self_val || other_val }
+          #
+          # XXX: We can't use #merge! here because Faraday::Env does not implement
+          # the method as same as Hash#merge! with Faraday v0.12.1.
+          @env.each do |k, v|
+            original = response.env[k]
+            response.env[k] = v if !original && v
+          end
         else
           response = yield
           store.write(key, response, options) if written_to_cache?


### PR DESCRIPTION
Current master branch can't pass tests due to Faraday's changes.
https://travis-ci.org/cookpad/garage_client/builds/210856611

Faraday::Env inherites Faraday::Options and its #merge! is different
from Hash#merge!. The method does not use given block and failed
merging when a value in `@env` with a key (A) is not nil but another
value in `response.env` with same key (A) is nil with NomethodError
on nil. The cause of the degression might be brought by
https://github.com/lostisland/faraday/pull/662 but I'm not sure now.
So for now, just work-around by using more primitive method, #each,
instread.

@cookpad/dev-infra FYI