### PR TITLE
Distributed tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ There are the following options:
 - `endpoint` - Garage application API endpoint (default: nil)
 - `path_prefix` - API path prefix (default: `'/v1'`)
 - `verbose` - Enable verbose http log (default: `false`)
-- `target_service` - (client instance only) Enable distributed tracing and set a logical name of the down stream service.
+- `tracing` - (client instance only) Enable distributed tracing and set a logical name of the down stream service. See detail in "Tracing" section below.
 
 You can configure the global settings:
 
@@ -200,3 +200,17 @@ end
 
 GarageClient::Client.new(cacher: MyCacher)
 ```
+
+## Tracing
+GarageClient supports distributed tracing. To enable tracing, specify `tracing.tracer` option for `GarageClient::Client` instance.
+Choose one of supported tracers from below. If you want to add new tracer, please give us a PR.
+
+### aws-xray
+Bundle [aws-xray](https://github.com/taiki45/aws-xray) gem in your `Gemfile`, then configure `GarageClient::Client` instance with `tracing.service` option:
+
+```ruby
+require 'aws/xray'
+GarageClient::Client.new(..., tracing: { tracer: 'aws-xray', service: 'user' })
+```
+
+`service` will be `name` of the sub segments.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ There are the following options:
 - `endpoint` - Garage application API endpoint (default: nil)
 - `path_prefix` - API path prefix (default: `'/v1'`)
 - `verbose` - Enable verbose http log (default: `false`)
+- `target_service` - (client instance only) Enable distributed tracing and set a logical name of the down stream service.
 
 You can configure the global settings:
 

--- a/garage_client.gemspec
+++ b/garage_client.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'hashie', '>= 1.2.0'
   s.add_dependency 'link_header'
 
+  s.add_dependency 'aws-xray'
   s.add_dependency 'system_timer' if RUBY_VERSION < '1.9'
 
   s.add_development_dependency "rails"

--- a/garage_client.gemspec
+++ b/garage_client.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'hashie', '>= 1.2.0'
   s.add_dependency 'link_header'
 
-  s.add_dependency 'aws-xray'
   s.add_dependency 'system_timer' if RUBY_VERSION < '1.9'
 
   s.add_development_dependency "rails"
@@ -33,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry"
   # Until bug fixed: https://github.com/colszowka/simplecov/issues/281
   s.add_development_dependency "simplecov", "~> 0.7.1"
+  s.add_development_dependency "aws-xray"
 end

--- a/lib/garage_client.rb
+++ b/lib/garage_client.rb
@@ -1,7 +1,6 @@
 require 'active_support/all'
 require 'faraday'
 require 'faraday_middleware'
-require 'aws/xray'
 
 require 'garage_client/version'
 require 'garage_client/cachers/base'

--- a/lib/garage_client.rb
+++ b/lib/garage_client.rb
@@ -1,6 +1,7 @@
 require 'active_support/all'
 require 'faraday'
 require 'faraday_middleware'
+require 'aws/xray'
 
 require 'garage_client/version'
 require 'garage_client/cachers/base'

--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -20,6 +20,8 @@ module GarageClient
     property :path_prefix
     property :verbose
 
+    # @option opts [String] :target_service enable tracing and
+    #   set a logical name of the down stream service.
     def initialize(options = {})
       require_necessaries(options)
       @options = options
@@ -57,6 +59,8 @@ module GarageClient
 
     def connection
       Faraday.new(headers: headers, url: endpoint) do |builder|
+        builder.use Aws::Xray::Faraday, options[:target_service] if options[:target_service]
+
         # Response Middlewares
         builder.use Faraday::Response::Logger if verbose
         builder.use FaradayMiddleware::Mashify

--- a/spec/features/tracing_spec.rb
+++ b/spec/features/tracing_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe 'Tracing support' do
+  context 'when `target_service` option is specified' do
+    around do |ex|
+      Aws::Xray.config.client_options = { sock: io }
+      Aws::Xray.trace(name: 'test-app') { ex.run }
+    end
+
+    let(:io) { Aws::Xray::TestSocket.new }
+    let(:client) do
+      GarageClient::Client.new(
+        adapter: [:test, stubs],
+        endpoint: 'http://127.0.0.1',
+        target_service: 'target-app',
+      )
+    end
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get('/campain') { |env| [200, {'Content-Type' => 'application/json'}, '{"campain": false}'] }
+      end
+    end
+
+    specify 'client enables tracing and sends trace data to a local agent' do
+      res = client.get('/campain')
+      expect(res.body.campain).to eq(false)
+
+      io.rewind
+      sent_jsons = io.read.split("\n")
+      expect(sent_jsons.size).to eq(2)
+      body = JSON.parse(sent_jsons[1])
+      expect(body['name']).to eq('target-app')
+    end
+  end
+end

--- a/spec/features/tracing_spec.rb
+++ b/spec/features/tracing_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
+require 'aws/xray'
 
 RSpec.describe 'Tracing support' do
-  context 'when `target_service` option is specified' do
+  context 'when `tracing` option is specified' do
     around do |ex|
       Aws::Xray.config.client_options = { sock: io }
       Aws::Xray.trace(name: 'test-app') { ex.run }
@@ -12,7 +13,10 @@ RSpec.describe 'Tracing support' do
       GarageClient::Client.new(
         adapter: [:test, stubs],
         endpoint: 'http://127.0.0.1',
-        target_service: 'target-app',
+        tracing: {
+          tracer: 'aws-xray',
+          service: 'target-app',
+        },
       )
     end
     let(:stubs) do


### PR DESCRIPTION
Suport ditributed tracing by adding configuration and set the configured tracer to Faraday middleware stack.

At first, we use [aws-xray](https://github.com/taiki45/aws-xray) tracer. But tracers are configurable and users should be able to choose or implement another tracing method.

@cookpad/dev-infra Please take a look at this.