### PR TITLE
Record http request/response even if API returns errors.

### DIFF
--- a/spec/features/tracing_spec.rb
+++ b/spec/features/tracing_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe 'Tracing support' do
     end
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.get('/campain') { |env| [200, {'Content-Type' => 'application/json'}, '{"campain": false}'] }
+        stub.get('/campaign') { |env| [200, {'Content-Type' => 'application/json'}, '{"campaign": false}'] }
       end
     end
 
     specify 'client enables tracing and sends trace data to a local agent' do
-      res = client.get('/campain')
-      expect(res.body.campain).to eq(false)
+      res = client.get('/campaign')
+      expect(res.body.campaign).to eq(false)
 
       io.rewind
       sent_jsons = io.read.split("\n")
@@ -39,12 +39,12 @@ RSpec.describe 'Tracing support' do
     context 'API returns client errors' do
       let(:stubs) do
         Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.get('/campain') { |env| [404, {'Content-Type' => 'application/json'}, '{"error": "not_found"}'] }
+          stub.get('/campaign') { |env| [404, {'Content-Type' => 'application/json'}, '{"error": "not_found"}'] }
         end
       end
 
       specify 'client traces HTTP request and response and records errors' do
-        expect { client.get('/campain') }.to raise_error(GarageClient::NotFound)
+        expect { client.get('/campaign') }.to raise_error(GarageClient::NotFound)
 
         io.rewind
         sent_jsons = io.read.split("\n")
@@ -60,12 +60,12 @@ RSpec.describe 'Tracing support' do
     context 'API returns server errors' do
       let(:stubs) do
         Faraday::Adapter::Test::Stubs.new do |stub|
-          stub.get('/campain') { |env| [500, {'Content-Type' => 'application/json'}, '{"error": "internal_server_error"}'] }
+          stub.get('/campaign') { |env| [500, {'Content-Type' => 'application/json'}, '{"error": "internal_server_error"}'] }
         end
       end
 
       specify 'client traces HTTP request and response and marks as fault' do
-        expect { client.get('/campain') }.to raise_error(GarageClient::InternalServerError)
+        expect { client.get('/campaign') }.to raise_error(GarageClient::InternalServerError)
 
         io.rewind
         sent_jsons = io.read.split("\n")

--- a/spec/features/tracing_spec.rb
+++ b/spec/features/tracing_spec.rb
@@ -35,5 +35,48 @@ RSpec.describe 'Tracing support' do
       body = JSON.parse(sent_jsons[1])
       expect(body['name']).to eq('target-app')
     end
+
+    context 'API returns client errors' do
+      let(:stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.get('/campain') { |env| [404, {'Content-Type' => 'application/json'}, '{"error": "not_found"}'] }
+        end
+      end
+
+      specify 'client traces HTTP request and response and records errors' do
+        expect { client.get('/campain') }.to raise_error(GarageClient::NotFound)
+
+        io.rewind
+        sent_jsons = io.read.split("\n")
+        expect(sent_jsons.size).to eq(2)
+        body = JSON.parse(sent_jsons[1])
+        expect(body['name']).to eq('target-app')
+        expect(body['error']).to eq(true)
+        expect(body['http']['request']['method']).to eq('GET')
+        expect(body['http']['response']['status']).to eq(404)
+      end
+    end
+
+    context 'API returns server errors' do
+      let(:stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.get('/campain') { |env| [500, {'Content-Type' => 'application/json'}, '{"error": "internal_server_error"}'] }
+        end
+      end
+
+      specify 'client traces HTTP request and response and marks as fault' do
+        expect { client.get('/campain') }.to raise_error(GarageClient::InternalServerError)
+
+        io.rewind
+        sent_jsons = io.read.split("\n")
+        expect(sent_jsons.size).to eq(2)
+        body = JSON.parse(sent_jsons[1])
+        expect(body['name']).to eq('target-app')
+        expect(body['error']).to eq(false)
+        expect(body['fault']).to eq(true)
+        expect(body['http']['request']['method']).to eq('GET')
+        expect(body['http']['response']['status']).to eq(500)
+      end
+    end
   end
 end


### PR DESCRIPTION
Re-order trace middleware to record HTTP request/response when HTTP errors are occured. Since garage_client raises an error on 4xx and 5xx, we have to place tracing middleware after RaiseHttpException middleware.

@cookpad/dev-infra FYI