### PR TITLE
Require aws-xray's faraday middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Choose one of supported tracers from below. If you want to add new tracer, pleas
 Bundle [aws-xray](https://github.com/taiki45/aws-xray) gem in your `Gemfile`, then configure `GarageClient::Client` instance with `tracing.service` option:
 
 ```ruby
-require 'aws/xray'
+require 'aws/xray/faraday'
 GarageClient::Client.new(..., tracing: { tracer: 'aws-xray', service: 'user' })
 ```
 

--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -76,6 +76,7 @@ module GarageClient
           when 'aws-xray'
             service = options[:tracing][:service]
             raise 'Configure target service name with `tracing.service`' unless service
+            require 'aws/xray/faraday'
             builder.use Aws::Xray::Faraday, service
           else
             raise "`tracing` option specified but GarageClient does not support the tracer: #{options[:tracing][:tracer]}"


### PR DESCRIPTION
By https://github.com/taiki45/aws-xray/pull/77, we don't require faraday middleware by default.

@cookpad/dev-infra FYI