### PR TITLE
Support query methods on GarageClient::Resource

### DIFF
--- a/lib/garage_client/resource.rb
+++ b/lib/garage_client/resource.rb
@@ -41,6 +41,8 @@ module GarageClient
         else
           value
         end
+      elsif query_method?(name)
+        data.__send__(name)
       elsif links.include?(name)
         path = data._links[name].href
         client.get(path, *args)
@@ -53,11 +55,20 @@ module GarageClient
     end
 
     def respond_to_missing?(name, include_private)
-      !!(properties.include?(name) || links.include?(name) || nested_resource_creation_method?(name))
+      !!(properties.include?(name) || query_method?(name) || links.include?(name) || nested_resource_creation_method?(name))
     end
 
     def nested_resource_creation_method?(name)
       !!(name =~ /\Acreate_(.+)\z/ && links.include?($1.to_sym))
+    end
+
+    private
+
+    def query_method?(name)
+      if name.to_s.end_with?('?')
+        key = name.to_s[0..-2]
+        properties.include?(key.to_sym)
+      end
     end
   end
 end

--- a/spec/garage_client/resource_spec.rb
+++ b/spec/garage_client/resource_spec.rb
@@ -84,6 +84,12 @@ describe GarageClient::Resource do
         resource.user.should be_kind_of(GarageClient::Resource)
       end
     end
+
+    context 'with property query' do
+      it 'returns presence' do
+        resource.name?.should == true
+      end
+    end
   end
 
   describe 'link' do


### PR DESCRIPTION
It would be nice if `GarageClient::Resource` provided a fluent interface similar to how [ActiveRecord allows querying of attributes](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/Query.html#method-i-query_attribute). The data in a `GarageClient::Resource` is in a [`Hashie::Mash`](https://github.com/intridea/hashie#methodaccess), which already provides querying of attributes.

This proposed change passes "query" style methods to the underlying Hashie::Mash.

e.g.

```ruby
resource.title
# => 'A resource'
resource.title?
# => true
resource.product_id
# => nil
resource.product_id?
# => false
```