### PR TITLE
Refactoring about Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: ruby
 
 rvm:
   - ruby-head
-  - 2.3.1
-  - 2.2.5
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
+  - 2.2.10
 matrix:
   allow_failures:
     - rvm: "ruby-head"

--- a/garage_client.gemspec
+++ b/garage_client.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'hashie', '>= 1.2.0'
   s.add_dependency 'link_header'
 
-  s.add_dependency 'system_timer' if RUBY_VERSION < '1.9'
-
   s.add_development_dependency "rails"
   s.add_development_dependency "rake", ">= 0.9.2"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
This pull request refactors about Ruby version. It does not affect user.
This pull request will update two things.

.travis.yml
---

First, it updates .travis.yml. I added new minor versions (2.5.3 and 2.4.5), and updated teeny versions (2.3.8 and 2.2.10).

88e80c1



Remove an unused dependency
---


Secondly, it removes an unused dependency, which is `system_timer`.
It is available with Ruby 1.8 or older, but garage_client does not support Ruby 1.8. This dependency is no longer needed.

1b815e8


