### PR TITLE
Use Module#module_parent_name for Rails6

### DIFF
--- a/lib/garage_client/railtie.rb
+++ b/lib/garage_client/railtie.rb
@@ -9,7 +9,13 @@ module GarageClient
     def self.set_default_name
       unless GarageClient.configuration.options[:name]
         GarageClient.configure do |c|
-          c.name = ::Rails.application.class.parent_name.underscore
+          klass = ::Rails.application.class
+          parent_name = if klass.respond_to?(:module_parent_name)
+            klass.module_parent_name
+          else
+            klass.parent_name
+          end
+          c.name = parent_name.underscore
         end
       end
     end


### PR DESCRIPTION
This PR suppresses DEPRECATION WARNING related to [this changes on Rails6](https://github.com/rails/rails/pull/34051).
I checked it works fine for my application based on Rails5.2 and Rails6 rc1 by this PR.

Please take a look.



