### PR TITLE
Remove dependency on activesupport

### DIFF
--- a/garage_client.gemspec
+++ b/garage_client.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.authors       = ['Cookpad Inc.']
   s.email         = ['kaihatsu@cookpad.com']
 
-  s.add_dependency 'activesupport', '> 3.2.0'
   s.add_dependency 'faraday', '>= 0.8.0'
   s.add_dependency 'faraday_middleware'
   s.add_dependency 'hashie', '>= 1.2.0'

--- a/lib/garage_client.rb
+++ b/lib/garage_client.rb
@@ -1,4 +1,3 @@
-require 'active_support/all'
 require 'faraday'
 require 'faraday_middleware'
 

--- a/spec/garage_client/cacher_spec.rb
+++ b/spec/garage_client/cacher_spec.rb
@@ -75,7 +75,7 @@ describe GarageClient::Cachers::Base do
 
       it "load data" do
         expect(res).to be_instance_of Faraday::Response
-        expect(res.env[:body]).to eq fixture("example.yaml")[:body]
+        expect(res.env[:body]).to eq fixture("example.yaml")["body"]
       end
     end
 
@@ -86,7 +86,7 @@ describe GarageClient::Cachers::Base do
 
       it "load data" do
         expect(res).to be_instance_of Faraday::Response
-        expect(res.env[:body]).to eq fixture("example.yaml")[:body]
+        expect(res.env[:body]).to eq fixture("example.yaml")["body"]
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,7 +47,7 @@ end
 def fixture(file)
   prefix = File.expand_path('../fixtures', __FILE__)
   path = File.join(prefix, file)
-  HashWithIndifferentAccess.new(YAML.load_file(path))
+  YAML.load_file(path)
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Remove atcivesupport from runtime dependency. It's only used sparingly in the spec.