### PR TITLE
Remove test that fails if faraday version is 1.0.0 or later

### DIFF
--- a/spec/garage_client/cacher_spec.rb
+++ b/spec/garage_client/cacher_spec.rb
@@ -64,10 +64,6 @@ describe GarageClient::Cachers::Base do
 
   # Check dump data. Because cache data not broken on the version up of faraday.
   describe "check Faraday::Response marshal" do
-    specify do
-      expect(Faraday::VERSION).to be < "1.0.0", "This spec is no longer needed. Delete this 'describe' section!"
-    end
-
     context "v0.9.1's marshal data" do
       let(:res) do
         Marshal.load(File.read(File.expand_path('../fixtures/faraday_0.9.1_response.dump', __dir__)))


### PR DESCRIPTION
The failure message suggests that we should remove the surrounding block altogether if tests are running with faraday > 1.0.0, but I don't really understand why the version of faraday with which tests are running matters when we still support 0.8.0 <= faraday < 1.0.0, so I just removed the failing test for now (though to be honest I'm not really sure what those tests which were added in #2 are trying to ensure).

https://github.com/cookpad/garage_client/blob/6562ae8b816a913029d26189d630050e21ef32d8/garage_client.gemspec#L19

CI is currently failing because of this test: https://travis-ci.org/github/cookpad/garage_client/jobs/750566301