### PR TITLE
Fix request ID not being propagated

### DIFF
--- a/lib/garage_client/request/propagate_request_id.rb
+++ b/lib/garage_client/request/propagate_request_id.rb
@@ -2,8 +2,8 @@ module GarageClient
   module Request
     class PropagateRequestId < Faraday::Middleware
       def call(env)
-        if Thread.current[:request_id] && !env[:request_headers]["HTTP_X_REQUEST_ID"]
-          env[:request_headers]["HTTP_X_REQUEST_ID"] = Thread.current[:request_id]
+        if Thread.current[:request_id] && !env[:request_headers]["X-Request-Id"]
+          env[:request_headers]["X-Request-Id"] = Thread.current[:request_id]
         end
         @app.call(env)
       end

--- a/spec/garage_client/request/propagate_request_id_spec.rb
+++ b/spec/garage_client/request/propagate_request_id_spec.rb
@@ -13,7 +13,7 @@ describe GarageClient::Request::PropagateRequestId do
   end
 
   it 'sends request_id via header' do
-    stub_get("/examples").with(headers: { 'HTTP_X_REQUEST_ID' => 'request_id' })
+    stub_get("/examples").with(headers: { 'X-Request-Id' => 'request_id' })
     expect { client.get("/examples") }.not_to raise_error
   end
 
@@ -24,7 +24,7 @@ describe GarageClient::Request::PropagateRequestId do
 
     it 'does not send request_id via header' do
       stub_get("/examples").with do |request|
-        !request.headers.include?('HTTP_X_REQUEST_ID')
+        !request.headers.include?('X-Request-Id')
       end
       expect { client.get("/examples") }.not_to raise_error
     end
@@ -32,11 +32,11 @@ describe GarageClient::Request::PropagateRequestId do
 
   context 'if already has request_id' do
     let(:client) do
-      GarageClient::Client.new(headers: { 'HTTP_X_REQUEST_ID' => 'another_id' })
+      GarageClient::Client.new(headers: { 'X-Request-Id' => 'another_id' })
     end
 
     it 'does not overwrite request_id' do
-      stub_get("/examples").with(headers: { 'HTTP_X_REQUEST_ID' => 'another_id' })
+      stub_get("/examples").with(headers: { 'X-Request-Id' => 'another_id' })
       expect { client.get("/examples") }.not_to raise_error
     end
   end


### PR DESCRIPTION
I think a key for `env[:request_headers]` is expected to just be an HTTP header name instead of HTTP_HEADER_NAME.

https://github.com/lostisland/faraday/blob/v0.8.0/lib/faraday/adapter/net_http.rb#L57
https://github.com/lostisland/faraday/blob/v0.8.0/lib/faraday/adapter/typhoeus.rb#L37