### PR TITLE
Stop using Module.delegate method

### DIFF
--- a/lib/garage_client.rb
+++ b/lib/garage_client.rb
@@ -23,11 +23,15 @@ end
 
 module GarageClient
   class << self
-    GarageClient::Configuration.keys.each do |key|
-      delegate key, "#{key}=", to: :configuration
-    end
+    [*GarageClient::Configuration.keys, :default_headers].each do |key|
+      define_method(key) do
+        configuration.public_send(key)
+      end
 
-    delegate 'default_headers', 'default_headers=', to: :configuration
+      define_method("#{key}=") do |value|
+        configuration.public_send("#{key}=", value)
+      end
+    end
 
     def configuration
       @configuration ||= GarageClient::Configuration.new


### PR DESCRIPTION
#29 has removed the runtime dependency on the activesupport gem and removed `require 'active_support/all'` but the [`Module.delegate`](https://api.rubyonrails.org/classes/Module.html#method-i-delegate) method added by Active Support core extensions is still used, thus causing a NoMethodError error if the extension is not loaded.

```
$ cat Gemfile
source 'https://rubygems.org'
gem 'garage_client'

$ bundle info garage_client
  * garage_client (2.4.4)
...

$ bundle exec irb -r garage_client
...
/path/to/garage_client/lib/garage_client.rb:27:in `block in singleton class': undefined method `delegate' for #<Class:GarageClient> (NoMethodError)
Did you mean?  DelegateClass
```