### PR TITLE
Drop support for Ruby < 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 
 rvm:
   - ruby-head
-  - 2.5.3
-  - 2.4.5
-  - 2.3.8
-  - 2.2.10
+  - 3.0.0
+  - 2.7.2
+  - 2.6.6
+  - 2.5.8
 matrix:
   allow_failures:
     - rvm: "ruby-head"


### PR DESCRIPTION
I'd like to drop support for Ruby 2.4 and older as they have reached their EOL: https://www.ruby-lang.org/en/downloads/branches/