### PR TITLE
Stop using Hash#stringify_keys method

### DIFF
--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -27,7 +27,7 @@ module GarageClient
     end
 
     def headers
-      @headers ||= GarageClient.configuration.headers.merge(given_headers.stringify_keys)
+      @headers ||= GarageClient.configuration.headers.merge(given_headers.transform_keys(&:to_s))
     end
     alias :default_headers :headers
 


### PR DESCRIPTION
#29 has removed the runtime dependency on the activesupport gem and removed `require 'active_support/all'` but the [`Hash#stringify_keys`](https://api.rubyonrails.org/classes/Hash.html#method-i-stringify_keys) method added by Active Support core extensions is still used, thus causing a NoMethodError error if the extension is not loaded.

```
$ cat Gemfile
source 'https://rubygems.org'
gem 'garage_client', git: 'https://github.com/cookpad/garage_client'

$ bundle info garage_client
  * garage_client (2.4.4 1bdc412)
...

$ bundle exec irb -r garage_client
irb(main):001:0> GarageClient.headers = {}
=> {}
irb(main):002:0> GarageClient::Client.new(endpoint: 'foo').headers
...
        1: from /path/to/garage_client/lib/garage_client/client.rb:30:in `headers'
NoMethodError (undefined method `stringify_keys' for {}:Hash)
```