### PR TITLE
Fix deprecation warning caused by using Faraday::Connection#authorization

### DIFF
--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -53,7 +53,7 @@ module GarageClient
     end
 
     def apply_auth_middleware(faraday_builder)
-      faraday_builder.authorization :Bearer, access_token if access_token
+      faraday_builder.request :authorization, :Bearer, access_token if access_token
     end
 
     def connection


### PR DESCRIPTION
Since https://github.com/lostisland/faraday/releases/tag/v1.7.1 , `Faraday::Connection#authorization` is marked as deprecated.

See also: https://github.com/lostisland/faraday/pull/1306

When running the tests which use Faraday 1.10.1, I found that the following deprecation warning is shown in log.

> WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.

This PR aims to avoid using `Faraday::Connection#authorization` to fix the deprecation warning.