### PR TITLE
Upgrade faraday gem to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,15 @@ jobs:
       fail-fast: true
       matrix:
         ruby:
-          - '2.5'
-          - '2.6'
-          - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
           - 'head'
-        gemfile:
-          - 'gemfiles/Gemfile.faraday-0.x'
-          - 'gemfiles/Gemfile.faraday-1.x'
-    env:
-      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
-    name: Run test with Ruby ${{ matrix.ruby }}, ${{ matrix.gemfile }}
+    name: Run test with Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/garage_client.gemspec
+++ b/garage_client.gemspec
@@ -10,14 +10,15 @@ Gem::Specification.new do |s|
   s.description   = s.summary
 
   s.files         = `git ls-files`.split($\)
-  s.executables   = s.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  s.executables   = s.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
   s.authors       = ['Cookpad Inc.']
   s.email         = ['kaihatsu@cookpad.com']
 
-  s.add_dependency 'faraday', '>= 0.8.0'
-  s.add_dependency 'faraday_middleware'
+  s.add_dependency 'faraday', '>= 2.0.1'
+  s.add_dependency 'faraday-mashify'
+  s.add_dependency 'faraday-multipart'
   s.add_dependency 'hashie', '>= 1.2.0'
   s.add_dependency 'link_header'
 

--- a/gemfiles/Gemfile.faraday-0.x
+++ b/gemfiles/Gemfile.faraday-0.x
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'faraday', '~> 0'
-gemspec path: '../'

--- a/gemfiles/Gemfile.faraday-1.x
+++ b/gemfiles/Gemfile.faraday-1.x
@@ -1,4 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'faraday', '~> 1'
-gemspec path: '../'

--- a/lib/garage_client.rb
+++ b/lib/garage_client.rb
@@ -1,5 +1,6 @@
 require 'faraday'
-require 'faraday_middleware'
+require 'faraday/mashify'
+require 'faraday/multipart'
 
 require 'garage_client/version'
 require 'garage_client/cachers/base'

--- a/lib/garage_client/cachers/base.rb
+++ b/lib/garage_client/cachers/base.rb
@@ -9,15 +9,9 @@ module GarageClient
       def call
         response = store.read(key, options) if read_from_cache?
         if response
-          # Faraday::Response#marshal_dump is drop request object and url
-          # https://github.com/lostisland/faraday/blob/edacd5eb57ea13accab3097649690ae5f48f421a/lib/faraday/response.rb#L74
-          #
-          # XXX: We can't use #merge! here because Faraday::Env does not implement
-          # the method as same as Hash#merge! with Faraday v0.12.1.
-          @env.each do |k, v|
-            original = response.env[k]
-            response.env[k] = v if !original && v
-          end
+          # Faraday::Response#marshal_dump drops the request object
+          # https://github.com/lostisland/faraday/blob/cc5d60776645d3d341ff0f425c45b3b3d48d98e0/lib/faraday/response.rb#L70
+          response.env.merge!(@env)
         else
           response = yield
           store.write(key, response, options) if written_to_cache?

--- a/lib/garage_client/client.rb
+++ b/lib/garage_client/client.rb
@@ -60,13 +60,13 @@ module GarageClient
       Faraday.new(headers: headers, url: endpoint) do |builder|
         # Response Middlewares
         builder.use Faraday::Response::Logger if verbose
-        builder.use FaradayMiddleware::Mashify
-        builder.use Faraday::Response::ParseJson, :content_type => /\bjson$/
+        builder.use Faraday::Mashify::Middleware
+        builder.use Faraday::Response::Json, content_type: /\bjson$/
         builder.use GarageClient::Response::Cacheable, cacher: cacher if cacher
         builder.use GarageClient::Response::RaiseHttpException
 
         # Request Middlewares
-        builder.use Faraday::Request::Multipart
+        builder.use Faraday::Multipart::Middleware
         builder.use GarageClient::Request::JsonEncoded
         builder.use GarageClient::Request::PropagateRequestId
 

--- a/lib/garage_client/response.rb
+++ b/lib/garage_client/response.rb
@@ -11,11 +11,9 @@ module GarageClient
       @client = client
       @response = response
 
-      # Faraday's Net::Http adapter returns '' if response is nil.
-      # Changes from faraday v0.9.0. faraday/f41ffaabb72d3700338296c79a2084880e6a9843
-      #
-      # GarageClient::Response#body should be always a String when Faraday
-      # became v1.0.0. Because 0.9.0 seems to be not stable.
+      # faraday-net_http adapter converts the response body from nil to '' to ensure the body is a string.
+      # https://github.com/lostisland/faraday/commit/f41ffaabb72d3700338296c79a2084880e6a9843
+      # https://github.com/lostisland/faraday-net_http/blob/11953160f75dd488133a74857c2b07d41be8995d/lib/faraday/adapter/net_http.rb#L186
       response.env[:body] = nil if response.env[:body] == ''
 
       unless ACCEPT_BODY_TYPES.any? {|type| type === response.body }

--- a/lib/garage_client/response/cacheable.rb
+++ b/lib/garage_client/response/cacheable.rb
@@ -1,8 +1,6 @@
-require "faraday_middleware"
-
 module GarageClient
   class Response
-    class Cacheable < Faraday::Response::Middleware
+    class Cacheable < Faraday::Middleware
       register_middleware cache: self
 
       def initialize(app, args)

--- a/lib/garage_client/response/raise_http_exception.rb
+++ b/lib/garage_client/response/raise_http_exception.rb
@@ -1,9 +1,6 @@
-require 'garage_client/error'
-require 'faraday_middleware'
-
 module GarageClient
   class Response
-    class RaiseHttpException < Faraday::Response::Middleware
+    class RaiseHttpException < Faraday::Middleware
       ClientErrorStatuses = 400...500
       ServerErrorStatuses = 500...600
 


### PR DESCRIPTION
and drop support for older Ruby versions since faraday v2.9.0 also drops support for those.

I'll bump the version of garage_client to v3.0.0 after merging this.

@cookpad/infra Would you please review this?